### PR TITLE
chore(config.py): reset default configuration values for talkgroups a…

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,12 +1,12 @@
 # adapt the following variables to your needs
-talkgroups = [312752,98638] # Talkgroups to monitor, seperated by commas
+talkgroups = [] # Talkgroups to monitor, seperated by commas
 callsigns = [] # Callsigns to monitor, seperated by commas
 noisy_calls = [] # Noisy calls signs that will be ignored
 min_duration = 0 # Min. duration of a QSO to qualify for a push notification
 min_silence = 300 # Min. time in seconds after the last QSO before a new push notification will be send
 verbose = True # Enable extra messages (console only)
 thread_map = {
-    "312752": "1319353057267683490",  # Replace with actual talkgroup and thread IDs
+    "123456": "12345678901234567890",  # Replace with actual talkgroup and thread IDs
 }
 
 # Pushover configuration
@@ -30,5 +30,5 @@ dapnet_callsigns = ["MYCALL"]
 dapnet_txgroup = "dl-all"
 
 # Discord Configuration
-discord = True
-discord_wh_url = 'https://discord.com/api/webhooks/1319099638170783784/6aLLten73sHzq9hiNGCptVIKTl4q39WgweuGfRyiYe6hn9FHKzDLb7VOdVi3W0V5ccAB'
+discord = False
+discord_wh_url = 'https://discord.com/api/webhooks/1234567890/abcdefghijklm'


### PR DESCRIPTION
…nd Discord webhook

The default talkgroups list is now empty, allowing users to customize it without pre-set values. The thread_map and discord_wh_url are updated with placeholder values to encourage users to replace them with actual data. Discord integration is disabled by default, providing a more secure initial setup.