### PR TITLE
docs(README.md): update changelog with version 1.3.1 release details

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This script will push a notification to the following services:
 
 ## Change Log
 
+- 12/20/2024 - Point Release 1.3.1 - Add TalkerAlias compatibility when posting to Discord
+
 - 12/19/2024 - Minor Update Release 1.3 - Add functionality to post Discord messages to Threads
 
 - 05/20/2024 - Minor Update Release 1.2 - Added Logic to handle multiple events from BM to correctly identify the event needed to send a notification message

--- a/bm_monitor.py
+++ b/bm_monitor.py
@@ -4,7 +4,7 @@
 # Developed by: Michael Clemens, DK1MI
 # Refactored by: Jeff Lehman, N8ACL
 # Further Refactoring by: mauvehed, K0MVH
-# Current Version: 1.3 (Threading Support Added)
+# Current Version: 1.3.1
 # Original Script: https://codeberg.org/mclemens/pyBMNotify
 # Refactored Script: https://github.com/n8acl/bm_monitor
 # Current Script: https://github.com/mauvehed/bm_monitor


### PR DESCRIPTION
chore(bm_monitor.py): update version number to 1.3.1

Add a new entry in the changelog for the point release 1.3.1, which introduces TalkerAlias compatibility when posting to Discord. Update the version number in the bm_monitor.py script to reflect this new release. These changes ensure that documentation and code versioning are consistent with the latest features and improvements.