### PR TITLE
fix(bm_monitor.py): add missing space in message construction

### DIFF
--- a/bm_monitor.py
+++ b/bm_monitor.py
@@ -77,7 +77,7 @@ def construct_message(c):
     time = dt.datetime.fromtimestamp(c["Start"], dt.timezone.utc).astimezone(ZoneInfo("US/Central")).strftime("%Y/%m/%d %H:%M")
     # construct text message from various transmission properties
     if c["TalkerAlias"]:
-        out += c["TalkerAlias"] + 'was active on '
+        out += c["TalkerAlias"] + ' was active on '
     else:
         out += c["SourceCall"] + ' (' + c["SourceName"] + ') was active on '
     if c["DestinationName"] != '':


### PR DESCRIPTION
Add a space between the TalkerAlias and the rest of the message to ensure proper formatting and readability of the output message. This change corrects a minor typographical error that could lead to confusing or unclear messages being generated.

## Summary by Sourcery

Bug Fixes:
- Fix message formatting issue to improve message clarity.