### PR TITLE
chore: add CODEOWNERS file to define code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All code currently owned by mauvehed
+*     @mauvehed


### PR DESCRIPTION
Introduce a CODEOWNERS file to specify that all code is currently owned by the user @mauvehed. This change helps in automatically assigning reviewers for pull requests and ensures that the appropriate person is notified for code reviews and changes.