### PR TITLE
chore(sourcery.yaml): update configuration for Sourcery tool

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -10,6 +10,7 @@ ignore: # A list of paths or files which Sourcery will ignore.
 - env
 - .env
 - .tox
+- config.ini
 
 rule_settings:
   enable:
@@ -22,11 +23,11 @@ rule_settings:
   python_version: '3.11' # A string specifying the lowest Python version your project supports. Sourcery will not suggest refactorings requiring a higher Python version.
 
 github:
-  labels:
-  - refactor
-  - python
-  - priority-low
   ignore_labels:
   - sourcery-ignore
-  request_review: mauvehed
+  - documentation
+  - wontfix
+  request_review:
+      origin: owner
+      forked: author
   sourcery_branch: sourcery/{base_branch}


### PR DESCRIPTION
Add 'config.ini' to the ignore list to prevent Sourcery from analyzing this configuration file. Update GitHub settings to refine the review process by specifying different reviewers for origin and forked repositories. Remove specific labels and add 'documentation' and 'wontfix' to the ignore list to streamline the labeling process. These changes aim to improve the configuration management and review workflow for the project.