### PR TITLE
chore(bm_monitor.py) comment out log handler for log file

### DIFF
--- a/bm_monitor.py
+++ b/bm_monitor.py
@@ -29,7 +29,7 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(),  # Ensure logs are sent to stdout
-        logging.FileHandler("brandmeister.log", encoding="utf-8")  # Log to file
+        #logging.FileHandler("brandmeister.log", encoding="utf-8")  # Log to file
     ]
 )
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove the file handler from the logger.